### PR TITLE
Add Personne store and CRUD page

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -4,8 +4,9 @@ const http = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   headers: {
     'Content-Type': 'application/json',
-    'Authorization': `Bearer ${import.meta.env.VITE_API_TOKEN}`,
   },
 })
+
+// Authorization header will be added by the auth store when a user logs in
 
 export default http

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,12 @@ import App from './App.vue'
 import { createPinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import router from './router'
+import { useAuthStore } from './stores/auth'
 const app = createApp(App)
 const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)
 app.use(pinia)
+// initialize auth store so axios has the correct token
+useAuthStore(pinia).init()
 app.use(router)
 app.mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LoginView from '../views/LoginView.vue'
 import HomeView from '../views/HomeView.vue'
+import PersonneView from '../views/PersonneView.vue'
 import { useAuthStore } from '../stores/auth'
 
 const routes = [
@@ -9,6 +10,11 @@ const routes = [
     path: '/',
     component: HomeView,
     meta: { requiresAuth: true }, // ← protected route
+  },
+  {
+    path: '/personnes',
+    component: PersonneView,
+    meta: { requiresAuth: true },
   },
 ]
 

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import http from '../http';
+import http from '../http'
 
 export const useAuthStore = defineStore('auth', {
   persist: true,
@@ -14,18 +14,29 @@ export const useAuthStore = defineStore('auth', {
   },
 
   actions: {
+    init() {
+      if (this.token) {
+        http.defaults.headers.common['Authorization'] = `Bearer ${this.token}`
+      }
+    },
     async login(email, password) {
       try {
         const res = await http.post('/login', { email, password })
         this.token = res.data.token
         this.user = res.data.user
         this.error = null
+        http.defaults.headers.common['Authorization'] = `Bearer ${this.token}`
         return true
       } catch (err) {
         console.log(err)
         this.error = err.response?.data?.message || 'Login failed'
         return false
       }
+    },
+    logout() {
+      this.user = null
+      this.token = null
+      delete http.defaults.headers.common['Authorization']
     },
   },
 })

--- a/src/stores/personne.js
+++ b/src/stores/personne.js
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia'
+import http from '../http'
+
+export const usePersonneStore = defineStore('personne', {
+  state: () => ({
+    personnes: [],
+    error: null,
+  }),
+  actions: {
+    async fetch() {
+      try {
+        const res = await http.get('/personne')
+        this.personnes = res.data
+        this.error = null
+      } catch (err) {
+        this.error = err.response?.data?.message || 'Failed to fetch personnes'
+      }
+    },
+    async create(data) {
+      try {
+        const res = await http.post('/personne', data)
+        this.personnes.push(res.data)
+        this.error = null
+      } catch (err) {
+        this.error = err.response?.data?.message || 'Create failed'
+      }
+    },
+    async update(id, data) {
+      try {
+        const res = await http.put(`/personne/${id}`, data)
+        const index = this.personnes.findIndex(p => p.id === id)
+        if (index !== -1) this.personnes[index] = res.data
+        this.error = null
+      } catch (err) {
+        this.error = err.response?.data?.message || 'Update failed'
+      }
+    },
+    async remove(id) {
+      try {
+        await http.delete(`/personne/${id}`)
+        this.personnes = this.personnes.filter(p => p.id !== id)
+        this.error = null
+      } catch (err) {
+        this.error = err.response?.data?.message || 'Delete failed'
+      }
+    },
+  },
+})

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,6 +2,7 @@
   <div class="container">
     <h1 class="title">Welcome</h1>
     <p class="subtitle">You are logged in!</p>
+    <router-link class="button is-link mt-4" to="/personnes">Manage Personnes</router-link>
   </div>
 </template>
 

--- a/src/views/PersonneView.vue
+++ b/src/views/PersonneView.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="container">
+    <h1 class="title">Personnes</h1>
+
+    <form @submit.prevent="save" class="box mb-5">
+      <div class="field">
+        <label class="label">Name</label>
+        <div class="control">
+          <input class="input" v-model="form.name" />
+        </div>
+      </div>
+      <div class="field">
+        <div class="control">
+          <button class="button is-primary" type="submit">
+            {{ form.id ? 'Update' : 'Add' }}
+          </button>
+          <button v-if="form.id" class="button ml-2" type="button" @click="reset">Cancel</button>
+        </div>
+      </div>
+    </form>
+
+    <table class="table is-fullwidth">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Name</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="p in store.personnes" :key="p.id">
+          <td>{{ p.id }}</td>
+          <td>{{ p.name }}</td>
+          <td>
+            <button class="button is-small mr-2" @click="edit(p)">Edit</button>
+            <button class="button is-small is-danger" @click="remove(p.id)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p v-if="store.error" class="has-text-danger">{{ store.error }}</p>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, reactive } from 'vue'
+import { usePersonneStore } from '../stores/personne'
+
+const store = usePersonneStore()
+
+const form = reactive({
+  id: null,
+  name: '',
+})
+
+onMounted(() => {
+  store.fetch()
+})
+
+function edit(p) {
+  form.id = p.id
+  form.name = p.name
+}
+
+function reset() {
+  form.id = null
+  form.name = ''
+}
+
+async function save() {
+  if (form.id) {
+    await store.update(form.id, { name: form.name })
+  } else {
+    await store.create({ name: form.name })
+  }
+  reset()
+}
+
+function remove(id) {
+  store.remove(id)
+}
+</script>


### PR DESCRIPTION
## Summary
- add pinia store for `personne` CRUD operations
- expose auth token via axios defaults
- call auth init on app start
- create `PersonneView` to manage persons
- link personne page from home
- register new route

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8df769a8832fb96e4d92ba0a3649